### PR TITLE
Add hspec-discover to build-tool-depends

### DIFF
--- a/json-api.cabal
+++ b/json-api.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.3.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8976c29f6aaf0752e3accb80f6d7f3ac432f94e1d8df9092d2f0cb9beaad86d5
+-- hash: 0e90747171e3e465a2db698390e798117af1897f7ca610cfc6c485041c819c26
 
 name:           json-api
 version:        0.1.4.0
@@ -19,7 +19,8 @@ maintainer:     Todd Mohney <toddmohney@gmail.com>
 copyright:      2016 Todd Mohney
 license:        MIT
 license-file:   LICENSE
-tested-with:    ghc ==7.10.3
+tested-with:
+    ghc ==7.10.3
 build-type:     Simple
 extra-source-files:
     README.md
@@ -97,3 +98,4 @@ test-suite json-api-test
     , unordered-containers
     , url
   default-language: Haskell2010
+  build-tool-depends: hspec-discover:hspec-discover

--- a/package.yaml
+++ b/package.yaml
@@ -78,5 +78,8 @@ tests:
     - bytestring
     - hspec
     - json-api
+    verbatim:
+      build-tool-depends:
+        hspec-discover:hspec-discover
 stability: experimental
 tested-with: ghc ==7.10.3


### PR DESCRIPTION
This allows cabal users to run the test suite