### PR TITLE
Remove ToJSON and FromJSON constraints from ResourcefulEntity

### DIFF
--- a/src/Network/JSONApi/Document.hs
+++ b/src/Network/JSONApi/Document.hs
@@ -147,7 +147,7 @@ Constructor function for the Document data type.
 Supports building compound documents
 <http://jsonapi.org/format/#document-compound-documents>
 -}
-mkIncludedResource :: ResourcefulEntity a => a -> Included
+mkIncludedResource :: (ResourcefulEntity a, ToJSON a) => a -> Included
 mkIncludedResource res = Included [AE.toJSON . R.toResource $ res]
 
 toResourceData :: ResourcefulEntity a => [a] -> ResourceData a

--- a/src/Network/JSONApi/Resource.hs
+++ b/src/Network/JSONApi/Resource.hs
@@ -65,7 +65,7 @@ instance HasIdentifier (Resource a) where
 {- |
 A typeclass for decorating an entity with JSON API properties
 -}
-class (ToJSON a, FromJSON a) => ResourcefulEntity a where
+class ResourcefulEntity a where
   resourceIdentifier :: a -> Text
   resourceType :: a -> Text
   resourceLinks :: a -> Maybe Links


### PR DESCRIPTION
These constraints don't give anything, and the relevant constraint
can be delegated to the call site when needed. I have some cases
where a type only has one or the other JSON direction
(eg. ToJSON but not FromJSON), and this constraint stops me
from being able to use ResourcefulEntity.