### PR TITLE
Split up functions for working with Document singletons and lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ to the [JSON-API pagination specification](https://jsonapi.org/format/#fetching-
 let paginate = Pagination (PageIndex 1) (PageSize 1) (ResourceCount $ toEnum (length usrs))
 let resourceLink = (fromJust . importURL) "/users"
 let paginationLinks = mkPaginationLinks PageStrategy resourceLink paginate
-let doc = mkDocument [head usrs] (Just paginationLinks) Nothing
+let doc = mkDocuments [head usrs] (Just paginationLinks) Nothing
 ```
 
 When delivered as a response from a web server, for example, we get a payload

--- a/src/Network/JSONApi.hs
+++ b/src/Network/JSONApi.hs
@@ -27,7 +27,11 @@ module Network.JSONApi
 , R.mkRelationship
 , R.mkRelationships
 , D.mkDocument
+, D.mkDocuments
 , D.mkDocument'
+, D.mkSimpleDocument
+, D.mkSimpleDocuments
+, D.mkSimpleDocument'
 , D.singleton
 , D.list
 , D.mkCompoundDocument

--- a/src/Network/JSONApi/Document.hs
+++ b/src/Network/JSONApi/Document.hs
@@ -7,12 +7,17 @@ module Network.JSONApi.Document
   , ErrorDocument (..)
   , Included
   , mkDocument
+  , mkDocuments
   , mkDocument'
   , singleton
   , list
   , mkCompoundDocument
+  , mkCompoundDocuments
   , mkCompoundDocument'
   , mkIncludedResource
+  , mkSimpleDocument
+  , mkSimpleDocuments
+  , mkSimpleDocument'
   ) where
 
 import Control.Monad (mzero)
@@ -95,11 +100,18 @@ See 'mkCompoundDocument' for constructing compound Document
 including 'side-loaded' resources
 -}
 mkDocument :: ResourcefulEntity a =>
-              [a]
+              a
            -> Maybe Links
            -> Maybe Meta
            -> Document a
 mkDocument res = mkDocument' (toResourceData res)
+
+mkDocuments :: ResourcefulEntity a =>
+              [a]
+           -> Maybe Links
+           -> Maybe Meta
+           -> Document a
+mkDocuments res = mkDocument' (toResourceDataMany res)
 
 mkDocument' :: ResourceData a
             -> Maybe Links
@@ -114,6 +126,26 @@ mkDocument' res links meta =
     }
 
 {- |
+A function for a single resourceful entity and document which do not
+require links or Meta data.
+-}
+mkSimpleDocument :: ResourcefulEntity a => a -> Document a
+mkSimpleDocument res = mkDocument res Nothing Nothing
+
+{- |
+A function for a multiple resourceful entities and document which do not
+require links or Meta data.
+-}
+mkSimpleDocuments :: ResourcefulEntity a => [a] -> Document a
+mkSimpleDocuments res = mkDocuments res Nothing Nothing
+
+{- |
+A function for document which do not require links or Meta data.
+-}
+mkSimpleDocument' :: ResourceData a -> Document a
+mkSimpleDocument' res = mkDocument' res Nothing Nothing
+
+{- |
 Constructor function for the Document data type.
 See 'mkIncludedResource' for constructing the 'Included' type.
 
@@ -121,12 +153,26 @@ Supports building compound documents
 <http://jsonapi.org/format/#document-compound-documents>
 -}
 mkCompoundDocument :: ResourcefulEntity a =>
-                      [a]
+                      a
                    -> Maybe Links
                    -> Maybe Meta
                    -> Included
                    -> Document a
 mkCompoundDocument res = mkCompoundDocument' (toResourceData res)
+
+{- |
+Constructor function for the Document data type.
+See 'mkIncludedResource' for constructing the 'Included' type.
+Supports building compound documents
+<http://jsonapi.org/format/#document-compound-documents>
+-}
+mkCompoundDocuments :: ResourcefulEntity a =>
+                      [a]
+                   -> Maybe Links
+                   -> Maybe Meta
+                   -> Included
+                   -> Document a
+mkCompoundDocuments res = mkCompoundDocument' (toResourceDataMany res)
 
 mkCompoundDocument' :: ResourceData a
                     -> Maybe Links
@@ -150,9 +196,11 @@ Supports building compound documents
 mkIncludedResource :: (ResourcefulEntity a, ToJSON a) => a -> Included
 mkIncludedResource res = Included [AE.toJSON . R.toResource $ res]
 
-toResourceData :: ResourcefulEntity a => [a] -> ResourceData a
-toResourceData (r:[]) = Singleton (R.toResource r)
-toResourceData rs     = List (map R.toResource rs)
+toResourceData :: ResourcefulEntity a => a -> ResourceData a
+toResourceData r = Singleton (R.toResource r)
+
+toResourceDataMany :: ResourcefulEntity a => [a] -> ResourceData a
+toResourceDataMany rs  = List (map R.toResource rs)
 
 {- |
 The 'Resource' type encapsulates the underlying 'Resource'

--- a/test/Network/JSONApi/DocumentSpec.hs
+++ b/test/Network/JSONApi/DocumentSpec.hs
@@ -19,8 +19,7 @@ spec :: Spec
 spec =
   describe "JSON serialization" $ do
     it "JSON encodes/decodes a singleton resource" $ do
-      -- TODO: test the main resource actually is a singleton
-      let jsonApiObj = mkDocument [testObject] Nothing Nothing
+      let jsonApiObj = mkDocument testObject Nothing Nothing
       let encodedJson = encodeDocumentObject jsonApiObj
       let decodedJson = decodeDocumentObject encodedJson
       putStrLn (BS.unpack encodedJson)
@@ -28,8 +27,7 @@ spec =
       isRight decodedJson `shouldBe` True
 
     it "JSON encodes/decodes a list of resources" $ do
-      -- TODO: test the main resource actually is a list
-      let jsonApiObj = mkDocument [testObject, testObject2] Nothing Nothing
+      let jsonApiObj = mkDocuments [testObject, testObject2] Nothing Nothing
       let encodedJson = encodeDocumentObject jsonApiObj
       let decodedJson = decodeDocumentObject encodedJson
       {- putStrLn (BS.unpack encodedJson) -}
@@ -37,7 +35,7 @@ spec =
       isRight decodedJson `shouldBe` True
 
     it "contains the allowable top-level keys" $ do
-      let jsonApiObj = mkDocument [testObject] Nothing Nothing
+      let jsonApiObj = mkDocument testObject Nothing Nothing
       let encodedJson = encodeDocumentObject jsonApiObj
       let dataObject = encodedJson ^? Lens.key "data"
       let linksObject = encodedJson ^? Lens.key "links"
@@ -49,7 +47,7 @@ spec =
       isJust includedObject `shouldBe` True
 
     it "allows an optional top-level links object" $ do
-      let jsonApiObj = mkDocument [testObject] (Just linksObj) Nothing
+      let jsonApiObj = mkDocument testObject (Just linksObj) Nothing
       let encodedJson = encodeDocumentObject jsonApiObj
       let decodedJson = decodeDocumentObject encodedJson
       -- putStrLn (BS.unpack encodedJson)
@@ -57,7 +55,7 @@ spec =
       isRight decodedJson `shouldBe` True
 
     it "allows an optional top-level meta object" $ do
-      let jsonApiObj = mkDocument [testObject] Nothing (Just testMetaObj)
+      let jsonApiObj = mkDocument testObject Nothing (Just testMetaObj)
       let encodedJson = encodeDocumentObject jsonApiObj
       let decodedJson = decodeDocumentObject encodedJson
       -- putStrLn (BS.unpack encodedJson)
@@ -66,7 +64,7 @@ spec =
 
     it "allows a heterogeneous list of related resources" $ do
       let includedResources = (mkIncludedResource testObject) <> (mkIncludedResource testObject2)
-      let jsonApiObj = mkCompoundDocument [testObject] Nothing Nothing includedResources
+      let jsonApiObj = mkCompoundDocument testObject Nothing Nothing includedResources
       let encodedJson = encodeDocumentObject jsonApiObj
       let decodedJson = decodeDocumentObject encodedJson
       {- putStrLn (BS.unpack encodedJson) -}


### PR DESCRIPTION
This clearer separation between singular and plural `Document`s is helpful in my work. What do you think?
This would be a breaking change, so if you merge this, we should bump the major version.

Further down this road, we could potentially even split `Document` and `Documents` into two types.